### PR TITLE
Add setup.py so it can be pip installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you're using the [matrix-docker-ansible-deploy](https://github.com/spantaleev
 
 If you'd like to install and configure this manually, make sure `shared_secret_authenticator.py` is on the Python path, somewhere where the Matrix Synapse server can find it.
 
-This would usually be something like `/usr/local/lib/python2.7/site-packages/shared_secret_authenticator.py`.
+Easiest way is `pip install git+https://github.com/devture/matrix-synapse-shared-secret-auth` but you can also manually add it to a path like `/usr/local/lib/python2.7/site-packages/shared_secret_authenticator.py`.
 
 
 ## Configuring

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="shared_secret_authenticator",
+    version="0.0.1",
+    py_modules=['shared_secret_authenticator'],
+    description="Shared Secret Authenticator password provider module for Matrix Synapse",
+    include_package_data=True,
+    zip_safe=True,
+    install_requires=[],
+)
+


### PR DESCRIPTION
setup.py makes it a little easier to not have to determine what path to put a file into (docker/different python version/etc)