### PR TITLE
Add note about packages like the `matrix.org` deb source

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ On [Archlinux](https://www.archlinux.org/), you can install one of these [AUR](h
 
 To install and configure this manually, make sure `shared_secret_authenticator.py` is on the Python path, somewhere where the Matrix Synapse server can find it.
 
-Easiest way is `pip install git+https://github.com/devture/matrix-synapse-shared-secret-auth` but you can also manually add it to a path like `/usr/local/lib/python3.7/site-packages/shared_secret_authenticator.py`.
+The easiest way is `pip install git+https://github.com/devture/matrix-synapse-shared-secret-auth` but you can also manually download `shared_secret_authenticator.py` from this repo to a path like `/usr/local/lib/python3.7/site-packages/shared_secret_authenticator.py`.
+
+Some distribution packages (such as the Debian packages from `matrix.org`) may use an isolated virtual environment, so you will need to install the library there. Any environments should be referenced in your init system - for example, the `matrix.org` Debian package creates a systemd init file at `/lib/systemd/system/matrix-synapse.service` that executes python from `/opt/venvs/matrix-synapse`.
 
 
 ## Configuring


### PR DESCRIPTION
This took some digging, figured I'd save future folks some trouble. `pip install` didn't work for me here, but just copying the file in manually seems to have done the trick.