### PR TITLE
Fix error handling of missing configuration

### DIFF
--- a/shared_secret_authenticator.py
+++ b/shared_secret_authenticator.py
@@ -33,7 +33,7 @@ class SharedSecretAuthProvider:
     def __init__(self, config: dict, api: module_api):
         for k in ('shared_secret',):
             if k not in config:
-                raise Error('Required `{0}` configuration key not found'.format(k))
+                raise KeyError('Required `{0}` configuration key not found'.format(k))
 
         m_login_password_support_enabled = bool(config['m_login_password_support_enabled']) if 'm_login_password_support_enabled' in config else False
 


### PR DESCRIPTION
Currently if you are missing a configuration item, you'll get `NameError: name 'Error' is not defined`, instead of ```Error: Required `shared_secret` configuration key not found```.

I think it's useful because when moving to Synapse 1.46 / this module 2.0, I didn't see that `sharedSecret` was renamed `shared_secret`.